### PR TITLE
Sir, there is no need of extra variable lvl.

### DIFF
--- a/Lecture064 Tree Interview Questions Day2/verticalTraversal.cpp
+++ b/Lecture064 Tree Interview Questions Day2/verticalTraversal.cpp
@@ -96,45 +96,40 @@ void printInorder(Node* root)
 
 
  // } Driver Code Ends
-class Solution
+lass Solution
 {
     public:
     //Function to find the vertical order traversal of Binary Tree.
     vector<int> verticalOrder(Node *root)
     {
-        map<int, map<int,vector<int> > > nodes;
-        queue< pair<Node*, pair<int,int> > > q;
+        map<int,vector<int> > nodes;
+        queue< pair<Node*, int > > q;
         vector<int> ans;
         
         if(root == NULL)
             return ans;
             
-        q.push(make_pair(root, make_pair(0,0)));
+        q.push(make_pair(root,0));
         
         while(!q.empty()) {
-            pair<Node*, pair<int,int> > temp = q.front();
+            pair<Node*, int> temp = q.front();
             q.pop();
             Node* frontNode = temp.first;
-            int hd = temp.second.first;
-            int lvl = temp.second.second;
+            int hd = temp.second;
             
-            nodes[hd][lvl].push_back(frontNode->data);
+            nodes[hd].push_back(frontNode->data);
             
             if(frontNode->left)
-                q.push(make_pair(frontNode->left, make_pair(hd-1, lvl+1) ));
+                q.push(make_pair(frontNode->left, hd-1 ));
                 
             if(frontNode->right)
-                q.push(make_pair(frontNode->right, make_pair(hd+1, lvl+1)));
+                q.push(make_pair(frontNode->right, hd+1));
         }
         
         for(auto i: nodes) {
             
             for(auto j:i.second) {
-                
-                for(auto k:j.second)
-                {
-                    ans.push_back(k);
-                }
+                ans.push_back(j);
             }
         }
         return ans;


### PR DESCRIPTION
I observed that lvl is not used in code for any computation, that's why i tried code by removing it. And it's working fine. Babbar Sir, Please merge the changes.

Below is my edited code - 

class Solution
{
    public:
    //Function to find the vertical order traversal of Binary Tree.
    vector<int> verticalOrder(Node *root)
    {
        map<int,vector<int> > nodes;
        queue< pair<Node*, int > > q;
        vector<int> ans;
        
        if(root == NULL)
            return ans;
            
        q.push(make_pair(root,0));
        
        while(!q.empty()) {
            pair<Node*, int> temp = q.front();
            q.pop();
            Node* frontNode = temp.first;
            int hd = temp.second;
            
            nodes[hd].push_back(frontNode->data);
            
            if(frontNode->left)
                q.push(make_pair(frontNode->left, hd-1 ));
                
            if(frontNode->right)
                q.push(make_pair(frontNode->right, hd+1));
        }
        
        for(auto i: nodes) {
            
            for(auto j:i.second) {
                ans.push_back(j);
            }
        }
        return ans;
    }
};