### PR TITLE
Updated the deleteNode function

### DIFF
--- a/Lecture044 Linked List Day1/doublyLinkedList.cpp
+++ b/Lecture044 Linked List Day1/doublyLinkedList.cpp
@@ -125,18 +125,17 @@ void deleteNode(int position, Node* & head) {
     {
         //deleting any middle node or last node
         Node* curr = head;
-        Node* prev = NULL;
 
         int cnt = 1;
         while(cnt < position) {
-            prev = curr;
             curr = curr -> next;
             cnt++;
         }
-
-        curr -> prev = NULL;
-        prev -> next = curr -> next;
-        curr -> next = NULL;
+        
+        curr->prev->next = curr->next;
+        curr->next->prev = curr->prev;
+        curr->next = NULL;
+        curr->prev = NULL;
 
         delete curr;
 


### PR DESCRIPTION
We don't need to keep a track of two pointers prev and curr to delete a node in doubly linkedlist. It can be done using single pointer only.