### PR TITLE
Destructor Correction in SinglyLL

### DIFF
--- a/Lecture044 Linked List Day1/singlyLinkedList.cpp
+++ b/Lecture044 Linked List Day1/singlyLinkedList.cpp
@@ -19,7 +19,6 @@ class Node {
         int value = this -> data;
         //memory free
         if(this->next != NULL) {
-            delete next;
             this->next = NULL;
         }
         cout << " memory is free for node with data " << value << endl;


### PR DESCRIPTION
In the destructor, we are deleting 'next' pointer, and then pointing 'next to null'. But this is wrong and can cause a segmentation fault, as the next pointer points to the next node (except the last node that points to NULL), so **DELETING NEXT POINTER WILL DELETE THE NEXT NODE.**

**IN THE LECTURE VIDEO WE GOT SEGMENTATION ERROR BECAUSE OF IT (Lecture 44 at 54:10)** , which was fixed by manually making 'next' pointer point to NULL before deletion which makes the faulty code to never run (LINE 21) thus no segmentation error, But it's still the wrong code.

I have debugged it properly! 