### PR TITLE
Correction of nonRepeating.cpp (Queues)

### DIFF
--- a/Lecture061 Queue Interview Questions/nonRepeating.cpp
+++ b/Lecture061 Queue Interview Questions/nonRepeating.cpp
@@ -22,7 +22,7 @@ class Solution {
 		            }
 		            else
 		            {
-		                ans.push_back(q.front());
+		                ans.push_back(q.back());
 		                break;
 		            }
 		        }


### PR DESCRIPTION
for eg.- String=aabc
if we add new elements to queue and print front element always with popping only repeating elements, we end up with answer a#bb instead it should be a#bc which we get by printing q.back()