### PR TITLE
Update reverseInKGroup.cpp as per updated hard problem

### DIFF
--- a/Lecture046 Linked List Day3/reverseInKGroup.cpp
+++ b/Lecture046 Linked List Day3/reverseInKGroup.cpp
@@ -17,6 +17,16 @@
 
 
 Node* kReverse(Node* head, int k) {
+    //when number of nodes is not a multiple of k, the left over ones are not to be reversed.
+    int size = 0;
+    Node* temp = head;
+
+    while(temp!=NULL){
+        temp = temp -> next;
+        size++;
+    }
+    if(size < k)return head;   
+    
     //base call
     if(head == NULL) {
         return NULL;


### PR DESCRIPTION
When number of nodes is not a multiple of k, the left over ones are not to be reversed.