### PR TITLE
Correct Integer Handling decToBin.cpp

### DIFF
--- a/Lecture006 Binary & Decimal Number System/decToBin.cpp
+++ b/Lecture006 Binary & Decimal Number System/decToBin.cpp
@@ -10,15 +10,21 @@ int main() {
 
 
     int ans  = 0;
-    int i = 0;
+    // int i = 0;
+    int place =1; // Start with 10^0 =1
+    
     while(n != 0 ) {
 
         int bit  = n & 1;
 
-        ans = (bit * pow(10, i) ) + ans;
+        // ans = (bit * pow(10, i) ) + ans;
+        
+        ans=(bit*place)+ans;
+        
 
         n = n >> 1;
-        i++;
+        // i++;
+        place *= 10; // Increment place value to 10^1, 10^2, etc.
 
     }
 


### PR DESCRIPTION
Using pow(10, i), which can cause floating-point precision errors.

Using pow(10, i) returns a floating-point value, which is then implicitly converted to an integer during the addition.This can result in precision issues. Instead, you should use integer multiplication for precise operations.

To ensure correct integer handling, we will replace pow(10, i) with  ans = (bit * place) + ans where place is multiplied by 10 in each loop iteration.