### PR TITLE
Update redundantBrackets.cpp

### DIFF
--- a/Lecture055 Stack Questions/redundantBrackets.cpp
+++ b/Lecture055 Stack Questions/redundantBrackets.cpp
@@ -1,35 +1,63 @@
-#include<stack>
+// #include<stack>
 
-bool findRedundantBrackets(string &s)
-{
-    stack<char> st;
-    for(int i=0; i<s.length(); i++) {
-        char ch =s[i];
+// bool findRedundantBrackets(string &s)
+// {
+//     stack<char> st;
+//     for(int i=0; i<s.length(); i++) {
+//         char ch =s[i];
         
-        if(ch == '(' || ch == '+' ||ch == '-' || ch == '*' || ch == '/') {
-            st.push(ch);
-        }
-        else
-        {
-            //ch ya toh ')' hai or lowercase letter
+//         if(ch == '(' || ch == '+' ||ch == '-' || ch == '*' || ch == '/') {
+//             st.push(ch);
+//         }
+//         else
+//         {
+//             //ch ya toh ')' hai or lowercase letter
             
-            if(ch == ')') {
-                bool isRedundant = true;
+//             if(ch == ')') {
+//                 bool isRedundant = true;
                 
-                while(st.top() != '(') {
-                    char top = st.top();
-                    if(top == '+' ||top == '-' || top == '*' || top == '/') {
-                        isRedundant = false;
-                    }
-                    st.pop();
+//                 while(st.top() != '(') {
+//                     char top = st.top();
+//                     if(top == '+' ||top == '-' || top == '*' || top == '/') {
+//                         isRedundant = false;
+//                     }
+//                     st.pop();
+//                 }
+                
+//                 if(isRedundant == true)
+//                     return true;
+//                 st.pop();
+//             }
+            
+//         } 
+//     }
+//     return false;
+// }
+
+#include <stack>
+#include <string>
+using namespace std;
+
+bool findRedundantBrackets(const string &s) {
+    stack<char> st;
+
+    for (char ch : s) {
+        if (ch == '(' || ch == '+' || ch == '-' || ch == '*' || ch == '/') {
+            st.push(ch);
+        } else if (ch == ')') {
+            bool hasOperator = false;
+
+            while (!st.empty() && st.top() != '(') {
+                if (st.top() == '+' || st.top() == '-' || st.top() == '*' || st.top() == '/') {
+                    hasOperator = true;
                 }
-                
-                if(isRedundant == true)
-                    return true;
                 st.pop();
             }
-            
-        } 
+
+            if (!st.empty()) st.pop(); // Pop '('
+
+            if (!hasOperator) return true; // Redundant brackets found
+        }
     }
     return false;
 }


### PR DESCRIPTION
Optimizations:
Avoid Unnecessary Stack Storage

Instead of pushing operators individually, check for redundancy directly. Reduce Stack Operations

If an operator is found inside the brackets, mark the brackets as non-redundant early. Prevent Stack Underflow

Ensure that st is not accessed when empty.