### PR TITLE
Fix: Reference lost bug and return types in Merge 2 Sorted Linked Lists

### DIFF
--- a/Lecture049 Linked List Day6/mergeList.cpp
+++ b/Lecture049 Linked List Day6/mergeList.cpp
@@ -21,9 +21,12 @@
     };
 
 ************************************************************/
-
-void solve(Node<int>* first, Node<int>* second) {
-    
+// Fix: Changed return type from void to Node<int>* to return the merged list head
+Node<int>* solve(Node<int>* first, Node<int>* second) {
+    if(first->next==NULL){   //If the next pointer of the first node is NULL, append it to the second linked list.
+        first->next=second;
+        return first;  // Fix: Added return statement to match the new function return type
+    }
     
     Node* curr1 = first;
     Node* next1 = curr1 -> next;
@@ -37,18 +40,24 @@ void solve(Node<int>* first, Node<int>* second) {
            && ( curr2 -> data <= next1 -> data)) {
             
             curr1 -> next = curr2;
+            next2=curr2->next;   //Fix: Reference lost bug in Merge 2 Sorted Linked Lists
             curr2 -> next = next1;
             curr1 = curr2;
             curr2 = next2;
         }
-        else {
+        else {     
+            curr1=next1;
+            next1=next1->next;
+            if(next1==NULL){
+                curr1->next=curr2;
+                return first;
             
         }
         
         
     }
     
-    
+    return first;// Fix: Returning the head of the merged sorted list
 }
 
 Node<int>* sortTwoLists(Node<int>* first, Node<int>* second)
@@ -60,12 +69,9 @@ Node<int>* sortTwoLists(Node<int>* first, Node<int>* second)
         return first;
     
     if(first -> data <= second -> data ){
-        solve(first, second);
+       return  solve(first, second);
     }
-    else
-    {
-        solve(second, first);
-    }
-    
-    
+   else{
+    return solve(second, first);
+}
 }


### PR DESCRIPTION
- Added missing return statement inside the else block when the first list reaches its end.
- Fixed pointer reference lost bug by saving ' next2 = curr2->next ' before updating links.
- Corrected the return type of ' solve() ' function from ' void ' to Node<int>*.